### PR TITLE
Fix up licensing information.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -33,7 +33,7 @@ dataset:
   - roll35/data/files/**/*
 
 documentation:
-  - LICENSE
+  - LICENSE.md
   - README.md
 
 infra:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,13 +1,17 @@
 Code is licensed under the MIT License with an additional clause requiring
 updated attributions for modified versions.
 
+Some files under the scripts directory are instead under different
+licenses. All such files contain the full license text of the relevant
+licenses.
+
 Data is licensed under the Open Gaming License version 1.0a
 
 ----
 
 Modified MIT License
 
-Copyright (c) 2020 Austin S. Hemmelgarn
+Copyright (c) 2020-2023 Austin S. Hemmelgarn
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,7 @@
 #!python
+#
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
 
 import logging
 import logging.config

--- a/convert_spells_csv.py
+++ b/convert_spells_csv.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) 2020 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
 
 import csv
 

--- a/roll35/__init__.py
+++ b/roll35/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 import asyncio
 import concurrent.futures
 import logging

--- a/roll35/armor.py
+++ b/roll35/armor.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Cog for handling armor items.'''
 
 import logging

--- a/roll35/cog.py
+++ b/roll35/cog.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Base class for all of our cogs.'''
 
 import logging

--- a/roll35/common.py
+++ b/roll35/common.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Common functions used throughout the module.'''
 
 import itertools

--- a/roll35/core.py
+++ b/roll35/core.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Core commands.'''
 
 import logging

--- a/roll35/data/agent.py
+++ b/roll35/data/agent.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Functions and classes for accessing item data.
 
    Data agents are used to encapsulate the data processed from our data

--- a/roll35/data/armor.py
+++ b/roll35/data/armor.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Data handling for armor and shields.'''
 
 import logging

--- a/roll35/data/category.py
+++ b/roll35/data/category.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Data agent for handling item categories.'''
 
 import logging

--- a/roll35/data/compound.py
+++ b/roll35/data/compound.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Data handling for compound item lists.'''
 
 import logging

--- a/roll35/data/ranked.py
+++ b/roll35/data/ranked.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Data handling for ranked item lists.'''
 
 import logging

--- a/roll35/data/spell.py
+++ b/roll35/data/spell.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Data agent for handling of spells.'''
 
 import asyncio

--- a/roll35/data/types.py
+++ b/roll35/data/types.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Data type definitons.
 
    These are simple lists of valid values for specific item properties.'''

--- a/roll35/data/weapons.py
+++ b/roll35/data/weapons.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Data handling for weapons.'''
 
 import logging

--- a/roll35/data/wondrous.py
+++ b/roll35/data/wondrous.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Data handling for wondrous item slots.'''
 
 import logging

--- a/roll35/magicitem.py
+++ b/roll35/magicitem.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Cog for handling magic items.'''
 
 import asyncio

--- a/roll35/parser.py
+++ b/roll35/parser.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Provides basic command parameter parsing functionality.'''
 
 import logging

--- a/roll35/renderer.py
+++ b/roll35/renderer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Render a message properly.'''
 
 import asyncio

--- a/roll35/spell.py
+++ b/roll35/spell.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Cog for handling spells.'''
 
 import logging

--- a/roll35/weapon.py
+++ b/roll35/weapon.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
+
 '''Cog for handling weapon items.'''
 
 import logging

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# Copyright (c) 2023 Austin S. Hemmelgarn
+# SPDX-License-Identifier: MITNFA
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
 


### PR DESCRIPTION
- Flag the license document as markdown.
- Add info about some files in `scripts` being under different licenses.
- Update copyright dates.
- Add SPDX license tags to files.