### PR TITLE
Fix magic ordnance cost calculations.

### DIFF
--- a/roll35/data/files/armor.yaml
+++ b/roll35/data/files/armor.yaml
@@ -212,8 +212,8 @@ specific:
 enchantments:
   armor:
     1:
-      - {weight:  6, name: 'Benevolent', cost: 2000}
-      - {weight:  6, name: 'Poison Resistant', cost: 2250}
+      - {weight:  6, name: 'Benevolent', bonuscost: 2000}
+      - {weight:  6, name: 'Poison Resistant', bonuscost: 2250}
       - {weight:  6, name: 'Balanced'}
       - {weight:  6, name: 'Bitter'}
       - {weight:  6, name: 'Bolstering', limit: {only: [medium, heavy]}}
@@ -229,21 +229,21 @@ enchantments:
       - {weight:  6, name: 'Staunching'}
       - {weight:  6, name: 'Warding'}
     2:
-      - {weight: 12, name: 'Glamered', cost: 2700}
-      - {weight: 12, name: 'Jousting', cost: 3750}
-      - {weight: 14, name: 'Shadow', cost: 3750, exclude: ['Improved Shadow', 'Greater Shadow']}
-      - {weight: 14, name: 'Slick', cost: 3750, exclude: ['Adhesive', 'Improved Slick', 'Greater Slick']}
-      - {weight: 12, name: 'Expiditious', cost: 4000}
-      - {weight: 12, name: 'Creeping', cost: 5000}
-      - {weight: 12, name: 'Rllying', cost: 5000}
+      - {weight: 12, name: 'Glamered', bonuscost: 2700}
+      - {weight: 12, name: 'Jousting', bonuscost: 3750}
+      - {weight: 14, name: 'Shadow', bonuscost: 3750, exclude: ['Improved Shadow', 'Greater Shadow']}
+      - {weight: 14, name: 'Slick', bonuscost: 3750, exclude: ['Adhesive', 'Improved Slick', 'Greater Slick']}
+      - {weight: 12, name: 'Expiditious', bonuscost: 4000}
+      - {weight: 12, name: 'Creeping', bonuscost: 5000}
+      - {weight: 12, name: 'Rllying', bonuscost: 5000}
       - {weight: 12, name: 'Spell Resistance (13)', exclude: ['Spell Resistance (15)', 'Spell Resistance (17)', 'Spell Resistance (19)']}
     3:
-      - {weight:  8, name: 'Adhesive', cost: 7000, exclude: ['Slick', 'Improved Slick', 'Greater Slick']}
+      - {weight:  8, name: 'Adhesive', bonuscost: 7000, exclude: ['Slick', 'Improved Slick', 'Greater Slick']}
       - {weight:  7, name: 'Brawling', limit: {only: [light]}}
-      - {weight:  7, name: 'Hosteling', cost: 7500}
-      - {weight:  9, name: 'Radiant', cost: 7500}
-      - {weight:  9, name: 'Delving', cost: 10000}
-      - {weight:  8, name: 'Putrid', cost: 10000}
+      - {weight:  7, name: 'Hosteling', bonuscost: 7500}
+      - {weight:  9, name: 'Radiant', bonuscost: 7500}
+      - {weight:  9, name: 'Delving', bonuscost: 10000}
+      - {weight:  8, name: 'Putrid', bonuscost: 10000}
       - {weight:  9, name: 'Moderate Fortification', exclude: ['Light Fortification', 'Heavy Fortification']}
       - {weight:  9, name: 'Ghost Touch'}
       - {weight:  9, name: 'Invulnerability'}
@@ -251,29 +251,29 @@ enchantments:
       - {weight:  8, name: 'Titanic'}
       - {weight:  8, name: 'Wild'}
     4:
-      - {weight: 16, name: 'Harmonizing', cost: 15000}
-      - {weight: 17, name: 'Improved Shadow', cost: 15000, exclude: ['Shadow', 'Greater Shadow']}
-      - {weight: 17, name: 'Improved Slick', cost: 15000, exclude: ['Adhesive', 'Slick', 'Greater Slick']}
-      - {weight: 17, name: '{{ keys.random("energy") }} Resistance', cost: 18000, exclude: ['Improved {{ keys.random("energy") }} Resistance', 'Greater {{ keys.random("energy") }} Resistance']}
-      - {weight: 16, name: 'Martyring', cost: 18000, exclude: ['Light Fortification', 'Moderate Fortification', 'Heavy Fortification']}
+      - {weight: 16, name: 'Harmonizing', bonuscost: 15000}
+      - {weight: 17, name: 'Improved Shadow', bonuscost: 15000, exclude: ['Shadow', 'Greater Shadow']}
+      - {weight: 17, name: 'Improved Slick', bonuscost: 15000, exclude: ['Adhesive', 'Slick', 'Greater Slick']}
+      - {weight: 17, name: '{{ keys.random("energy") }} Resistance', bonuscost: 18000, exclude: ['Improved {{ keys.random("energy") }} Resistance', 'Greater {{ keys.random("energy") }} Resistance']}
+      - {weight: 16, name: 'Martyring', bonuscost: 18000, exclude: ['Light Fortification', 'Moderate Fortification', 'Heavy Fortification']}
       - {weight: 17, name: 'Spell Resistance (17)', exclude: ['Spell Resistance (13)', 'Spell Resistance (15)', 'Spell Resistance (19)']}
     5:
-      - {weight:  8, name: 'Righteous', cost: 27000, exclude: ['Unrighteous']}
-      - {weight:  7, name: 'Unbound', cost: 27000, exclude: ['Vigilant']}
-      - {weight:  8, name: 'Unrighteous', cost: 27000, exclude: ['Righteous']}
-      - {weight:  7, name: 'Vigilant', cost: 27000, exclude: ['Unbound']}
-      - {weight:  7, name: 'Determination', cost: 30000}
-      - {weight:  8, name: 'Greater Shadow', cost: 33750, exclude: ['Shadow', 'Improved Shadow']}
-      - {weight:  8, name: 'Greater Slick', cost: 33750, exclude: ['Adhesive', 'Slick', 'Improved Slick']}
-      - {weight:  8, name: 'Improved {{ keys.random("energy") }} Resistance', cost: 42000, exclude: ['{{ keys.random("energy") }} Resistance', 'Greater {{ keys.random("energy") }} Resistance']}
-      - {weight:  8, name: 'Etherealness', cost: 49000}
-      - {weight:  7, name: 'Undead Controlling', cost: 49000}
-      - {weight:  8, name: 'Greater {{ keys.random("energy") }} Resistance', cost: 66000, exclude: ['{{ keys.random("energy") }} Resistance', 'Improved {{ keys.random("energy") }} Resistance']}
+      - {weight:  8, name: 'Righteous', bonuscost: 27000, exclude: ['Unrighteous']}
+      - {weight:  7, name: 'Unbound', bonuscost: 27000, exclude: ['Vigilant']}
+      - {weight:  8, name: 'Unrighteous', bonuscost: 27000, exclude: ['Righteous']}
+      - {weight:  7, name: 'Vigilant', bonuscost: 27000, exclude: ['Unbound']}
+      - {weight:  7, name: 'Determination', bonuscost: 30000}
+      - {weight:  8, name: 'Greater Shadow', bonuscost: 33750, exclude: ['Shadow', 'Improved Shadow']}
+      - {weight:  8, name: 'Greater Slick', bonuscost: 33750, exclude: ['Adhesive', 'Slick', 'Improved Slick']}
+      - {weight:  8, name: 'Improved {{ keys.random("energy") }} Resistance', bonuscost: 42000, exclude: ['{{ keys.random("energy") }} Resistance', 'Greater {{ keys.random("energy") }} Resistance']}
+      - {weight:  8, name: 'Etherealness', bonuscost: 49000}
+      - {weight:  7, name: 'Undead Controlling', bonuscost: 49000}
+      - {weight:  8, name: 'Greater {{ keys.random("energy") }} Resistance', bonuscost: 66000, exclude: ['{{ keys.random("energy") }} Resistance', 'Improved {{ keys.random("energy") }} Resistance']}
       - {weight:  8, name: 'Heavy Fortification', exclude: ['Light Fortification', 'Moderate Fortification']}
       - {weight:  8, name: 'Spell Resistance (19)', exclude: ['Spell Resistance (13)', 'Spell Resistance (15)', 'Spell Resistance (17)']}
   shield:
     1:
-      - {weight: 10, name: 'Poison Resistant', cost: 2250}
+      - {weight: 10, name: 'Poison Resistant', bonuscost: 2250}
       - {weight:  9, name: 'Arrow Catching'}
       - {weight:  9, name: 'Bashing'}
       - {weight:  9, name: 'Blinding'}
@@ -285,28 +285,28 @@ enchantments:
       - {weight:  9, name: 'Mirrored', limit: {only: [metal]}}
       - {weight:  9, name: 'Ramming', limit: {only: [light, heavy]}}
     2:
-      - {weight: 15, name: 'Rallying', cost: 5000}
-      - {weight: 15, name: 'Wyrmbreath ({{ keys.random("elemental") }})', cost: 5000}
+      - {weight: 15, name: 'Rallying', bonuscost: 5000}
+      - {weight: 15, name: 'Wyrmbreath ({{ keys.random("elemental") }})', bonuscost: 5000}
       - {weight: 20, name: 'Animated', limit: {not: [tower]}}
       - {weight: 17, name: 'Arrow Deflection'}
       - {weight: 15, name: 'Merging', limit: {only: [light, heavy]}}
       - {weight: 18, name: 'Spell Resistance (13)', exclude: ['Spell Resistance (15)', 'Spell Resistance (17)', 'Spell Resistance (19)']}
     3:
-      - {weight: 15, name: 'Hosteling', cost: 7500}
-      - {weight: 17, name: 'Radiant', cost: 7500}
+      - {weight: 15, name: 'Hosteling', bonuscost: 7500}
+      - {weight: 17, name: 'Radiant', bonuscost: 7500}
       - {weight: 17, name: 'Moderate Fortification', exclude: ['Light Fortification', 'Heavy Fortification']}
       - {weight: 17, name: 'Ghost Touch'}
       - {weight: 17, name: 'Spell Resistance (15)', exclude: ['Spell Resistance (13)', 'Spell Resistance (17)', 'Spell Resistance (19)']}
       - {weight: 15, name: 'Wild'}
       # The SRD table is missing entries covering 99 and 100.
     4:
-      - {weight: 50, name: '{{ keys.random("energy") }} Resistance', cost: 18000, exclude: ['Improved {{ keys.random("energy") }} Resistance', 'Greater {{ keys.random("energy") }} Resistance']}
+      - {weight: 50, name: '{{ keys.random("energy") }} Resistance', bonuscost: 18000, exclude: ['Improved {{ keys.random("energy") }} Resistance', 'Greater {{ keys.random("energy") }} Resistance']}
       - {weight: 50, name: 'Spell Resistance (17)', exclude: ['Spell Resistance (13)', 'Spell Resistance (15)', 'Spell Resistance (19)']}
     5:
-      - {weight: 11, name: 'Determination', cost: 30000}
-      - {weight: 16, name: 'Improved {{ keys.random("energy") }} Resistance', cost: 42000, exclude: ['{{ keys.random("energy") }} Resistance', 'Greater {{ keys.random("energy") }} Resistance']}
-      - {weight: 11, name: 'Undead Controlling', cost: 49000}
-      - {weight: 17, name: 'Greater {{ keys.random("energy") }} Resistance', cost: 66000, exclude: ['{{ keys.random("energy") }} Resistance', 'Improved {{ keys.random("energy") }} Resistance']}
+      - {weight: 11, name: 'Determination', bonuscost: 30000}
+      - {weight: 16, name: 'Improved {{ keys.random("energy") }} Resistance', bonuscost: 42000, exclude: ['{{ keys.random("energy") }} Resistance', 'Greater {{ keys.random("energy") }} Resistance']}
+      - {weight: 11, name: 'Undead Controlling', bonuscost: 49000}
+      - {weight: 17, name: 'Greater {{ keys.random("energy") }} Resistance', bonuscost: 66000, exclude: ['{{ keys.random("energy") }} Resistance', 'Improved {{ keys.random("energy") }} Resistance']}
       - {weight: 15, name: 'Heavy Fortification', exclude: ['Light Fortification', 'Moderate Fortification']}
       - {weight: 15, name: 'Reflecting'}
       - {weight: 15, name: 'Spell Resistance (19)', exclude: ['Spell Resistance (13)', 'Spell Resistance (15)', 'Spell Resistance (17)']}

--- a/roll35/data/files/weapon.yaml
+++ b/roll35/data/files/weapon.yaml
@@ -598,7 +598,7 @@ enchantments:
   ranged:
     1:
       - {weight:  1, name: 'Adaptive', bonuscost: 1000, limit: {only: [composite]}}
-      - {weight:  1, name: 'Impervious', bonuscost: 3000 }
+      - {weight:  1, name: 'Impervious', bonuscost: 3000}
       - {weight:  1, name: 'Glamered', bonuscost: 4000}
       - {weight:  2, name: 'Allying'}
       - {weight:  9, name: '{{ keys.random("bane") }} Bane'}

--- a/roll35/data/files/weapon.yaml
+++ b/roll35/data/files/weapon.yaml
@@ -514,8 +514,8 @@ specific:
 enchantments:
   melee:
     1:
-      - {weight:  1, name: 'Impervious', cost: 3000}
-      - {weight:  1, name: 'Glamered', cost: 4000}
+      - {weight:  1, name: 'Impervious', bonuscost: 3000}
+      - {weight:  1, name: 'Glamered', bonuscost: 4000}
       - {weight:  1, name: 'Allying'}
       - {weight:  5, name: '{{ keys.random("bane") }} Bane'}
       - {weight:  1, name: 'Benevolent'}
@@ -592,14 +592,14 @@ enchantments:
     4:
       - {weight: 40, name: 'Brilliant Energy'}
       - {weight: 40, name: 'Dancing'}
-      - {weight: 10, name: 'Vorpal', cost: 50000, limit: {only: [slashing]}}
-      - {weight:  5, name: 'Transformative', cost: 10000}
-      - {weight:  5, name: 'Dueling', cost: 14000}
+      - {weight: 10, name: 'Vorpal', bonus: 5, limit: {only: [slashing]}}
+      - {weight:  5, name: 'Transformative', bonuscost: 10000}
+      - {weight:  5, name: 'Dueling', bonuscost: 14000}
   ranged:
     1:
-      - {weight:  1, name: 'Adaptive', cost: 1000, limit: {only: [composite]}}
-      - {weight:  1, name: 'Impervious', cost: 3000 }
-      - {weight:  1, name: 'Glamered', cost: 4000}
+      - {weight:  1, name: 'Adaptive', bonuscost: 1000, limit: {only: [composite]}}
+      - {weight:  1, name: 'Impervious', bonuscost: 3000 }
+      - {weight:  1, name: 'Glamered', bonuscost: 4000}
       - {weight:  2, name: 'Allying'}
       - {weight:  9, name: '{{ keys.random("bane") }} Bane'}
       - {weight:  1, name: 'Called'}
@@ -636,18 +636,18 @@ enchantments:
       - {weight: 10, name: 'Shocking Burst', exclude: ['Shock']}
       - {weight:  4, name: 'Stalking'}
       - {weight: 10, name: 'Unholy', exclude: ['Holy']}
-    3: &ranged_enchant_3
+    3:
       - {weight: 25, name: 'Greater Lucky', exclude: ['Lucky'], limit: {only: [firearm]}}
       - {weight: 20, name: 'Greatre Reliable', exclude: ['Reliable'], limit: {only: [firearm]}}
       - {weight: 40, name: 'Speed'}
-      - {weight:  9, name: 'Brilliant Energy', cost: 32000}
-      - {weight:  2, name: 'Greater Designating', cost: 32000, exclude: ['Lesser Designating']}
-      - {weight:  2, name: 'Nimble Shot', cost: 32000}
-      - {weight:  2, name: 'Second Chance', cost: 32000, limit: {only: [bow]}}
-    4: *ranged_enchant_3
+    4:
+      - {weight:  9, name: 'Brilliant Energy'}
+      - {weight:  2, name: 'Greater Designating', exclude: ['Lesser Designating']}
+      - {weight:  2, name: 'Nimble Shot'}
+      - {weight:  2, name: 'Second Chance', limit: {only: [bow]}}
   ammo:
     1:
-      - {weight:  5, name: 'Dry Load', cost: 1500, limit: {only: [cartridge]}}
+      - {weight:  5, name: 'Dry Load', bonuscost: 1500, limit: {only: [cartridge]}}
       - {weight: 11, name: '{{ keys.random("bane") }} Bane'}
       - {weight:  1, name: 'Conductive'}
       - {weight: 11, name: 'Corrosive', exclude: ['Corrosive Burst']}
@@ -675,6 +675,6 @@ enchantments:
       - {weight: 10, name: 'Shocking Burst', exclude: ['Shock']}
       - {weight: 10, name: 'Unholy', exclude: ['Holy']}
     3: &ammo_enchant_3
-      - {weight:  2, name: 'Brilliant Energy', cost: 32000}
-      - {weight:  1, name: 'Greater Designating', cost: 32000, exclude: ['Lesser Designating']}
+      - {weight:  2, name: 'Brilliant Energy', bonus: 4}
+      - {weight:  1, name: 'Greater Designating', bonus: 4, exclude: ['Lesser Designating']}
     4: *ammo_enchant_3

--- a/roll35/magicitem.py
+++ b/roll35/magicitem.py
@@ -147,8 +147,11 @@ class MagicItem(Cog):
                 case enchant:
                     enchants.append(enchant['name'])
 
-                    if 'cost' in enchant:
-                        extra_ecost += enchant['cost']
+                    if 'bonuscost' in enchant:
+                        extra_ecost += enchant['bonuscost']
+
+                    if 'bonus' in enchant:
+                        cbonus += enchant['bonus']
                     else:
                         cbonus += ebonus
 


### PR DESCRIPTION
- Base price modifiers are on top of the ‘normal’ cost of the enchantment, not in place of it.
- Enchantments with a specific bonus value should be handled correctly.