### PR TITLE
Split item rolling logic from magic item cog.

### DIFF
--- a/roll35/data/__init__.py
+++ b/roll35/data/__init__.py
@@ -40,12 +40,18 @@ class DataSet:
             structure = yaml.load(f)
 
         self.renderdata = structure['renderdata']
+        self._types = {k: set() for k in agents.keys()}
 
         for item in structure['agents']:
             self._agents[item['name']] = agents[item['type']](self, pool, item['name'])
+            self._types[item['type']].add(item['name'])
 
     def __getitem__(self, key):
         return self._agents[key]
+
+    @property
+    def types(self):
+        return self._types
 
     async def load_data(self):
         '''Load the data for this dataset.'''

--- a/roll35/data/category.py
+++ b/roll35/data/category.py
@@ -6,7 +6,8 @@
 import logging
 
 from . import agent
-from ..common import DATA_ROOT, yaml
+from . import types
+from ..common import DATA_ROOT, yaml, check_ready
 
 logger = logging.getLogger(__name__)
 
@@ -17,8 +18,20 @@ class CategoryAgent(agent.Agent):
 
     @staticmethod
     def _loader(name):
-        with open(DATA_ROOT / 'category.yaml') as f:
-            return yaml.load(f)
+        with open(DATA_ROOT / f'{ name }.yaml') as f:
+            data = yaml.load(f)
+
+        data['categories'] = set()
+
+        for rank in types.RANK:
+            for cat in [x['value'] for x in data[rank]]:
+                data['categories'].add(cat)
+
+        return data
 
     async def random(self, rank=None):
         return await super().random_compound(rank)
+
+    @check_ready
+    async def categories(self):
+        return self._data['categories']


### PR DESCRIPTION
Also determine categories dynamically at runtime in the item rolling logic instead of hard coding them.

Closes: #125 