### PR TITLE
Add support for rolling multiple items or spells at the same time.

### DIFF
--- a/roll35/__main__.py
+++ b/roll35/__main__.py
@@ -109,6 +109,10 @@ def main(token):
             asyncio.create_task(renderer.load_data()),
         )
 
+    @bot.event
+    async def on_close():
+        POOL.shutdown(wait=True, cancel_futures=True)
+
     for entry in COGS:
         cog = entry(bot, ds, renderer)
         bot.add_cog(cog)

--- a/roll35/core.py
+++ b/roll35/core.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class Core(Cog):
-    def __init__(self, bot, ds, renderer):
+    def __init__(self, bot, ds, renderer, logger=logger):
         super().__init__(bot, ds, renderer, logger)
 
     @commands.command()

--- a/roll35/magicitem.py
+++ b/roll35/magicitem.py
@@ -69,6 +69,7 @@ ITEM_PARSER = Parser({
     'mincost': {
         'type': int,
         'names': [
+            'mincost',
             'minc',
             'costmin',
             'cmin',
@@ -77,6 +78,7 @@ ITEM_PARSER = Parser({
     'maxcost': {
         'type': int,
         'names': [
+            'maxcost',
             'maxc',
             'costmax',
             'cmax',
@@ -85,6 +87,7 @@ ITEM_PARSER = Parser({
     'count': {
         'type': int,
         'names': [
+            'count',
             'co',
             'number',
             'num',

--- a/roll35/magicitem.py
+++ b/roll35/magicitem.py
@@ -149,18 +149,28 @@ class MagicItem(Cog):
                     k: v for k, v in enumerate(args) if k != 'count'
                 })
 
-                for item in asyncio.as_completed(items):
-                    await ctx.trigger_typing()
+                await ctx.trigger_typing()
 
+                results = []
+
+                for item in asyncio.as_completed(items):
                     match await item:
                         case (False, msg):
-                            await ctx.send(msg)
+                            results.append(f'\nFailed to generate remaining items: { msg }')
+                            break
                         case (True, msg):
                             match await self.render(msg):
                                 case (True, msg):
-                                    await ctx.send(msg)
+                                    results.append(msg)
                                 case (False, msg):
-                                    await ctx.send(msg)
+                                    results.append(f'\nFailed to generate remaining items: { msg }')
+                                    break
+
+                await ctx.trigger_typing()
+
+                msg = '\n'.join(results)
+
+                await ctx.send(f'{ len(results) } results: \n{ msg }')
             case {'count': c} if c < 1:
                 await ctx.send('Count must be an integer greater than 0.')
             case _:

--- a/roll35/spell.py
+++ b/roll35/spell.py
@@ -40,6 +40,7 @@ SPELL_PARSER = Parser({
     'count': {
         'type': int,
         'names': [
+            'cost',
             'co',
             'number',
             'num',


### PR DESCRIPTION
Uses a new parameter `count` for the commands. All relevant results are obtained prior to responding to avoid hitting Discord rate limits.

Also fixes a bug in the parser definitions for the commands.

Closes: #119 