### PR TITLE
Increase reroll limit from 8 to 32.

### DIFF
--- a/roll35/magicitem.py
+++ b/roll35/magicitem.py
@@ -16,7 +16,7 @@ from .parser import Parser
 NOT_READY = 'Magic item data is not yet available, please try again later.'
 NO_ITEMS_IN_COST_RANGE = 'No items found in requested cost range.'
 
-MAX_REROLLS = 8
+MAX_REROLLS = 32
 MAX_COUNT = 20
 
 ITEM_PARSER = Parser({


### PR DESCRIPTION
Individual reroll attempts are in general not exceptionally expensive, but having a low limit increases the probability of failing to find a valid item within the requested price range when asking for items based on cost limits.

Increasing the limit should have little to no impact on the common case, but should enable much narrower cost limits to work more frequently.