### PR TITLE
Fix handling of cost filtering of items.

### DIFF
--- a/roll35/data/compound.py
+++ b/roll35/data/compound.py
@@ -136,8 +136,8 @@ class CompoundAgent(agent.Agent):
             rank: types.Rank | None = None,
             *,
             level: int,
-            mincost: types.item.Cost | None = None,
-            maxcost: types.item.Cost | None = None) -> \
+            mincost: types.Cost = agent.DEFAULT_MINCOST,
+            maxcost: types.Cost = agent.DEFAULT_MAXCOST) -> \
             types.CompoundItem | types.item.CompoundSpellItem | types.Ret:
         if self._data.compound is None:
             return types.Ret.NO_MATCH
@@ -204,15 +204,15 @@ class CompoundAgent(agent.Agent):
 
     @log_call(logger, 'roll compound item')
     def random(
-            self: CompoundAgent,
-            /,
-            rank: types.Rank | None = None,
-            *,
-            cls: str | None = None,
-            level: int | None = None,
-            mincost: types.item.Cost | None = None,
-            maxcost: types.item.Cost | None = None) -> \
-            types.CompoundItem | types.item.CompoundSpellItem | types.Ret:
+        self: CompoundAgent,
+        /,
+        rank: types.Rank | None = None,
+        *,
+        cls: str | None = None,
+        level: int | None = None,
+        mincost: types.Cost = agent.DEFAULT_MINCOST,
+        maxcost: types.Cost = agent.DEFAULT_MAXCOST,
+    ) -> types.CompoundItem | types.item.CompoundSpellItem | types.Ret:
         '''Roll a random item, then roll a spell for it if needed.'''
         match level:
             case None:
@@ -240,15 +240,15 @@ class CompoundAgent(agent.Agent):
 
     @log_call_async(logger, 'roll compound item')
     async def random_async(
-            self: CompoundAgent,
-            /,
-            rank: types.Rank | None = None,
-            *,
-            cls: str | None = None,
-            level: int | None = None,
-            mincost: types.item.Cost | None = None,
-            maxcost: types.item.Cost | None = None) -> \
-            types.CompoundItem | types.item.CompoundSpellItem | types.Ret:
+        self: CompoundAgent,
+        /,
+        rank: types.Rank | None = None,
+        *,
+        cls: str | None = None,
+        level: int | None = None,
+        mincost: types.Cost = agent.DEFAULT_MINCOST,
+        maxcost: types.Cost = agent.DEFAULT_MAXCOST,
+    ) -> types.CompoundItem | types.item.CompoundSpellItem | types.Ret:
         '''Roll a random item, then roll a spell for it if needed.'''
         match level:
             case None:

--- a/roll35/data/ranked.py
+++ b/roll35/data/ranked.py
@@ -268,7 +268,7 @@ class RankedAgent(agent.Agent):
         cls: str | None = None,
         mincost: types.Cost = agent.DEFAULT_MINCOST,
         maxcost: types.Cost = agent.DEFAULT_MAXCOST,
-    ) ->  types.item.BaseItem | types.Ret:
+    ) -> types.item.BaseItem | types.Ret:
         '''Roll a random ranked item, then roll a spell for it if needed.'''
         match level:
             case None:

--- a/roll35/data/ranked.py
+++ b/roll35/data/ranked.py
@@ -143,8 +143,8 @@ class RankedAgent(agent.Agent):
             subrank: types.Subrank | None = None,
             *,
             level: int,
-            mincost: types.Cost | None = None,
-            maxcost: types.Cost | None = None) -> \
+            mincost: types.Cost = agent.DEFAULT_MINCOST,
+            maxcost: types.Cost = agent.DEFAULT_MAXCOST) -> \
             types.item.BaseItem | types.Ret:
         if self._data.ranked is None:
             return types.Ret.NO_MATCH
@@ -221,16 +221,16 @@ class RankedAgent(agent.Agent):
 
     @log_call(logger, 'roll random ranked item')
     def random(
-            self: RankedAgent,
-            /,
-            rank: types.Rank | None = None,
-            subrank: types.Subrank | None = None,
-            *,
-            level: int | None = None,
-            cls: str | None = None,
-            mincost: types.Cost | None = None,
-            maxcost: types.Cost | None = None) -> \
-            types.item.BaseItem | types.Ret:
+        self: RankedAgent,
+        /,
+        rank: types.Rank | None = None,
+        subrank: types.Subrank | None = None,
+        *,
+        level: int | None = None,
+        cls: str | None = None,
+        mincost: types.Cost = agent.DEFAULT_MINCOST,
+        maxcost: types.Cost = agent.DEFAULT_MAXCOST,
+    ) -> types.item.BaseItem | types.Ret:
         '''Roll a random ranked item, then roll a spell for it if needed.'''
         match level:
             case None:
@@ -259,16 +259,16 @@ class RankedAgent(agent.Agent):
 
     @log_call_async(logger, 'roll random ranked item')
     async def random_async(
-            self: RankedAgent,
-            /,
-            rank: types.Rank | None = None,
-            subrank: types.Subrank | None = None,
-            *,
-            level: int | None = None,
-            cls: str | None = None,
-            mincost: types.Cost | None = None,
-            maxcost: types.Cost | None = None) -> \
-            types.item.BaseItem | types.Ret:
+        self: RankedAgent,
+        /,
+        rank: types.Rank | None = None,
+        subrank: types.Subrank | None = None,
+        *,
+        level: int | None = None,
+        cls: str | None = None,
+        mincost: types.Cost = agent.DEFAULT_MINCOST,
+        maxcost: types.Cost = agent.DEFAULT_MAXCOST,
+    ) ->  types.item.BaseItem | types.Ret:
         '''Roll a random ranked item, then roll a spell for it if needed.'''
         match level:
             case None:

--- a/roll35/data/wondrous.py
+++ b/roll35/data/wondrous.py
@@ -61,21 +61,34 @@ class WondrousAgent(agent.Agent):
 
         return True
 
-    def __random(self: WondrousAgent, /, *, mincost: types.Cost | None = None, maxcost: types.Cost | None = None) -> str | types.Ret:
+    def __random(
+        self: WondrousAgent,
+        /, *,
+        mincost: types.Cost = agent.DEFAULT_MINCOST,
+        maxcost: types.Cost = agent.DEFAULT_MAXCOST,
+    ) -> str | types.Ret:
         '''Return a random slot, possibly limited by cost.'''
         return rnd(agent.costfilter(self._data.slots, mincost=mincost, maxcost=maxcost))
 
-    @agent.ensure_costs
     @log_call(logger, 'roll random wondrous item slot')
     @types.check_ready(logger)
-    def random(self: WondrousAgent, /, *, mincost: types.Cost | None = None, maxcost: types.Cost | None = None) -> str | types.Ret:
+    def random(
+        self: WondrousAgent,
+        /, *,
+        mincost: types.Cost = agent.DEFAULT_MINCOST,
+        maxcost: types.Cost = agent.DEFAULT_MAXCOST,
+    ) -> str | types.Ret:
         '''Return a random slot, possibly limited by cost.'''
         return self.__random(mincost=mincost, maxcost=maxcost)
 
-    @agent.ensure_costs
     @log_call_async(logger, 'roll random wondrous item slot')
     @types.check_ready_async(logger)
-    async def random_async(self: WondrousAgent, /, *, mincost: types.Cost | None = None, maxcost: types.Cost | None = None) -> str | types.Ret:
+    async def random_async(
+        self: WondrousAgent,
+        /, *,
+        mincost: types.Cost = agent.DEFAULT_MINCOST,
+        maxcost: types.Cost = agent.DEFAULT_MAXCOST,
+    ) -> str | types.Ret:
         '''Return a random slot, possibly limited by cost.'''
         return self.__random(mincost=mincost, maxcost=maxcost)
 


### PR DESCRIPTION
The `roll35.agent.ensure_costs` decorator was working incorrectly in almost all cases, which lead to cost filtering essnetially not happening at all.

Instead of relying on a decorator, simply provide sane default values for the cost filtering options so that they don’t need special handling.